### PR TITLE
Changes needed to pass the test suite with clean gemset.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ gem "ParseTree"
 
 gem "minitest"
 gem "test-unit"
+gem "rspec"
 
 # until predicated is a released gem, I've put it directly into this project
-# gem "predicated"
+gem "predicated", :path => "lib/predicated"
 
 gem "diff"
 gem "diff-lcs"

--- a/test/suite.rb
+++ b/test/suite.rb
@@ -1,4 +1,4 @@
 #simple way to make sure requires are isolated
-result = Dir["test/**/*_test.rb"].collect{|test_file| system("ruby #{test_file}") }.uniq == [true]
+result = Dir["test/**/*_test.rb"].collect{|test_file| system("bundle exec ruby #{test_file}") }.uniq == [true]
 puts "suite " + (result ? "passed" : "FAILED")
 exit(result ? 0 : 1)


### PR DESCRIPTION
This fixes the following errors:

```
<internal:lib/rubygems/custom_require>:29:in `require': no such file to load -- predicated/predicate (LoadError)
/Users/jfire/Development/wrong/lib/wrong/adapters/rspec.rb:1:in `require': no such file to load -- spec (LoadError)
```
