### PR TITLE
JRuby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source :gemcutter
 gem "ruby_parser"
 gem "ruby2ruby"
-gem "ParseTree"
 
 gem "minitest"
 gem "test-unit"

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :default => :test
 desc 'run all tests (in all ruby versions if rvm is installed)'
 task :test do
   rvm = `which rvm`.strip
-  ruby = rvm == "" ? "ruby" : "#{rvm} ruby,1.8.6,1.8.7,1.9.1,1.9.2"
+  ruby = rvm == "" ? "ruby" : "#{rvm} ruby,1.8.6,1.8.7,1.9.1,1.9.2,jruby"
   sh "#{ruby} test/suite.rb"
 end
 

--- a/lib/predicated/lib/predicated/from/callable_object.rb
+++ b/lib/predicated/lib/predicated/from/callable_object.rb
@@ -35,6 +35,7 @@ require "predicated/from/ruby_code_string"
 module Predicated
   
   require_gem_version("ParseTree", "3.0.5", "parse_tree") if RUBY_VERSION < "1.9"
+  require "predicated/sexp_patch"
   
   class Predicate
 
@@ -64,44 +65,6 @@ module Predicated
         ruby_code_string = Ruby2Ruby.translate(temp_class, :serializable)    
         ruby_code_string.sub(/^def serializable\n  /, "").sub(/\nend$/, "")
       end
-    end
-    
-    #see http://gist.github.com/321038
-    # # Monkey-patch to have Ruby2Ruby#translate with r2r >= 1.2.3, from
-    # # http://seattlerb.rubyforge.org/svn/ruby2ruby/1.2.2/lib/ruby2ruby.rb
-    class ::Ruby2Ruby < ::SexpProcessor
-      def self.translate(klass_or_str, method = nil)
-        sexp = ParseTree.translate(klass_or_str, method)
-        unifier = Unifier.new
-        unifier.processors.each do |p|
-          p.unsupported.delete :cfunc # HACK
-        end
-        sexp = unifier.process(sexp)
-        self.new.process(sexp)
-      end
-      
-      #sconover - 7/2010 - monkey-patch
-      #{1=>2}=={1=>2}
-      #The right side was having its braces cut off because of 
-      #special handling of hashes within arglists within the seattlerb code.
-      #I tried to fork r2r and add a test, but a lot of other tests
-      #broke, and I just dont understand the test in ruby2ruby.
-      #So I'm emailing the author...
-      def process_hash(exp)
-        result = []
-        until exp.empty?
-          lhs = process(exp.shift)
-          rhs = exp.shift
-          t = rhs.first
-          rhs = process rhs
-          rhs = "(#{rhs})" unless [:lit, :str].include? t # TODO: verify better!
-
-          result << "#{lhs} => #{rhs}"
-        end
-
-        return "{ #{result.join(', ')} }"
-      end
-
     end
     
   end

--- a/lib/predicated/lib/predicated/from/ruby_code_string.rb
+++ b/lib/predicated/lib/predicated/from/ruby_code_string.rb
@@ -5,6 +5,7 @@ module Predicated
 
   require_gem_version("ruby_parser", "2.0.4")
   require_gem_version("ruby2ruby", "1.2.4")
+  require "predicated/sexp_patch"
 
   class Predicate
     def self.from_ruby_code_string(ruby_predicate_string, context=binding())

--- a/lib/predicated/lib/predicated/sexp_patch.rb
+++ b/lib/predicated/lib/predicated/sexp_patch.rb
@@ -1,0 +1,39 @@
+
+
+#see http://gist.github.com/321038
+# # Monkey-patch to have Ruby2Ruby#translate with r2r >= 1.2.3, from
+# # http://seattlerb.rubyforge.org/svn/ruby2ruby/1.2.2/lib/ruby2ruby.rb
+class ::Ruby2Ruby < ::SexpProcessor
+  def self.translate(klass_or_str, method = nil)
+    sexp = ParseTree.translate(klass_or_str, method)
+    unifier = Unifier.new
+    unifier.processors.each do |p|
+      p.unsupported.delete :cfunc # HACK
+    end
+    sexp = unifier.process(sexp)
+    self.new.process(sexp)
+  end
+
+  #sconover - 7/2010 - monkey-patch
+  #{1=>2}=={1=>2}
+  #The right side was having its braces cut off because of
+  #special handling of hashes within arglists within the seattlerb code.
+  #I tried to fork r2r and add a test, but a lot of other tests
+  #broke, and I just dont understand the test in ruby2ruby.
+  #So I'm emailing the author...
+  def process_hash(exp)
+    result = []
+    until exp.empty?
+      lhs = process(exp.shift)
+      rhs = exp.shift
+      t = rhs.first
+      rhs = process rhs
+      rhs = "(#{rhs})" unless [:lit, :str].include? t # TODO: verify better!
+
+      result << "#{lhs} => #{rhs}"
+    end
+
+    return "{ #{result.join(', ')} }"
+  end
+
+end

--- a/lib/wrong/assert.rb
+++ b/lib/wrong/assert.rb
@@ -1,5 +1,5 @@
 require "predicated/predicate"
-require "predicated/from/callable_object"
+require "predicated/from/ruby_code_string"
 require "predicated/to/sentence"
 require "wrong/chunk"
 require "wrong/config"

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -52,7 +52,7 @@ describe "basic assert features" do
 
       it "gives a meaningful error when passed no block" do
         e = get_error {
-          @m.assert (2+2 == 5)
+          @m.assert(2+2 == 5)
         }
         assert e.message =~ /a block/
       end


### PR DESCRIPTION
Good news -- it turned out to be much easier than expected. Wrong doesn't really need to have a dependency on ParseTree at all -- just ruby_parser, which works fine on JRuby. The ParseTree dependency came from a part of predicated that wrong doesn't actually use. A bit of refactoring and all tests passed!
