### PR TITLE
Include Wrong::CloseTo in Numeric so it works for all Numerics

### DIFF
--- a/lib/wrong/close_to.rb
+++ b/lib/wrong/close_to.rb
@@ -4,6 +4,5 @@ module Wrong
       (self.to_f - other.to_f).abs < tolerance
     end
   end
-  Float.send :include, CloseTo
-  Fixnum.send :include, CloseTo
+  Numeric.send :include, CloseTo
 end

--- a/test/close_to_test.rb
+++ b/test/close_to_test.rb
@@ -1,6 +1,7 @@
 require "./test/test_helper"
 require "wrong/close_to"
 require "wrong"
+require "bigdecimal"
 
 describe "#close_to? (monkey patch for float comparison)" do
   include Wrong
@@ -34,6 +35,12 @@ describe "#close_to? (monkey patch for float comparison)" do
     assert { 5.close_to? 5.0001 }
     deny   { 5.close_to? 5.1 }
     assert { 5.close_to? 5.1, 0.5 }
+  end
+  
+  it "also works for bigdecimals" do    
+    assert { BigDecimal.new("5.0").close_to? 5 }
+    assert { BigDecimal.new("5.0").close_to? 5.0001 }
+    deny   { BigDecimal.new("5.0").close_to? 5.1 }
   end
 
 end


### PR DESCRIPTION
Hi

i came across one situation when JRuby was behaving a little different than MRI and gave me a BigDecimal where MRI used to return a Float. It did not really matter for the project, but using Wrong::CloseTo in my assertion did not work, because only Float and Fixnum could respond to 'close_to?'.

So here's a tiny fix for that, just including CloseTo in Numeric. 
Love the name, 'wrong'.
