### PR TITLE
fix Wrong::D test failure

### DIFF
--- a/test/d_test.rb
+++ b/test/d_test.rb
@@ -28,7 +28,10 @@ describe "d" do
     output = capturing do
       d { x }
     end
-    assert { output == "x is {:a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\n :b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}\n" }
+    assert do 
+      output == "x is {:a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\n :b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}\n" || 
+      output == "x is {:b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\n :a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n"
+    end
   end
 
   it "works on an expression" do


### PR DESCRIPTION
Hello again.

The test I patched fails on my machine, like so:

```
   1) Failure:
test_0003_pretty_prints_the_value(DSpec) [./test/d_test.rb:31]:
Expected (output == "x is {:a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\n :b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}\n"), but
Strings differ at position 7:
 first: "x is {:b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"...
second: "x is {:a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"...
    output is "x is {:b=>\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
      bbbbbbb\",\n :a=>\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      aaaaa\"}\n"
```

I'm using ruby 1.8.7 (2011-02-18 patchlevel 334) [i686-darwin10.7.1], MBARI 0x6770, Ruby Enterprise Edition 2011.03
From what I know the order of a hash's elements isn't guaranteed by ruby. I wasn't really sure how to fix the test. Maybe you want to change the test to use arrays instead of a hash, or two hashes in an array? If you want me to do that instead, let me know and I will.

Eugen.
