### PR TITLE
Plug require_optionally for a random change in the error message style for 1.9.3p0

### DIFF
--- a/lib/wrong/chunk.rb
+++ b/lib/wrong/chunk.rb
@@ -6,7 +6,7 @@ def require_optionally(library)
   begin
     require library
   rescue LoadError => e
-    raise e unless e.message == "no such file to load -- #{library}"
+    raise e unless e.message == "no such file to load -- #{library}" || e.message == "cannot load such file -- #{library}"
   end
 end
 


### PR DESCRIPTION
The fact that this changed at some point from "no such file to load" to "cannot load such file" is exactly what the term "turd polishing" was invented for.

Could you push this to a new gem version pretty plz? It's breaking my travis CI for 1.9.3.
