### PR TITLE
Fix for Issue 16 "Wrong::Config.read_here_or_higher can't handle absolute paths"

### DIFF
--- a/lib/wrong/config.rb
+++ b/lib/wrong/config.rb
@@ -1,4 +1,3 @@
-
 module Wrong
 
   def self.load_config
@@ -25,7 +24,7 @@ module Wrong
     end
 
     def self.read_here_or_higher(file, dir = ".")
-      File.read "#{dir}/#{file}"
+      File.read get_file_path(file, dir)
     rescue Errno::ENOENT, Errno::EACCES => e
       # we may be in a chdir underneath where the file is, so move up one level and try again
       parent = "#{dir}/..".gsub(/^(\.\/)*/, '')
@@ -33,6 +32,14 @@ module Wrong
         raise Errno::ENOENT, "couldn't find #{file}"
       end
       read_here_or_higher(file, parent)
+    end
+
+    def self.get_file_path(file, dir)
+      if File.file?(file)
+        file
+      else
+        "#{dir}/#{file}"
+      end
     end
 
     def initialize(string = nil)

--- a/test/chunk_test.rb
+++ b/test/chunk_test.rb
@@ -19,6 +19,20 @@ describe Chunk do
     end
   end
 
+  describe "#read_source_file" do
+    it "handles absolute file paths" do
+      chunk = Wrong::Chunk.new(nil, 0)
+      f = File.new "abs_file_path_test_file.tmp", "w"
+      abs_path = File.absolute_path(f.path)
+      assert(chunk.read_source_file(abs_path).is_a? String)
+    end
+    it "handles relative file paths" do
+      chunk = Wrong::Chunk.new(nil, 0)
+      rel_path = './chunk_test.rb'
+      assert(chunk.read_source_file(rel_path).is_a? String)
+    end
+  end
+
   describe "line numbers" do
     before do
       @chunk = Wrong::Chunk.new("foo.rb", 10)


### PR DESCRIPTION
I'm not the most experienced Rubyist, but I've been enjoying using Wrong, and thought I'd have a go at fixing this issue since most of my hobbyprogramming is done on windows. 

My approach is simply to check whether a path is absolute or relative by calling File.file? on it.
