### PR TITLE
Eliminating Ruby warnings

### DIFF
--- a/lib/wrong/assert.rb
+++ b/lib/wrong/assert.rb
@@ -26,7 +26,7 @@ module Wrong
       if block.nil?
         begin
           super(*args) # if there's a framework assert method (sans block), then call it
-        rescue NoMethodError => e
+        rescue NoMethodError
           # note: we're not raising an AssertionFailedError because this is a programmer error, not a failed assertion
           raise "You must pass a block to Wrong's assert and deny methods"
         end

--- a/lib/wrong/chunk.rb
+++ b/lib/wrong/chunk.rb
@@ -76,7 +76,7 @@ module Wrong
           capturing(:stderr) do  # new RubyParser is too loud
             sexp = @parser.parse(@chunk)
           end
-        rescue Racc::ParseError => e
+        rescue Racc::ParseError
           # loop and try again
           c += 1
         end

--- a/lib/wrong/config.rb
+++ b/lib/wrong/config.rb
@@ -4,7 +4,7 @@ module Wrong
   def self.load_config
     settings = begin
       Config.read_here_or_higher(".wrong")
-    rescue Errno::ENOENT => e
+    rescue Errno::ENOENT
       # couldn't find it
       nil # In Ruby 1.8, "e" would be returned here otherwise
     end
@@ -26,7 +26,7 @@ module Wrong
 
     def self.read_here_or_higher(file, dir = ".")
       File.read "#{dir}/#{file}"
-    rescue Errno::ENOENT, Errno::EACCES => e
+    rescue Errno::ENOENT, Errno::EACCES
       # we may be in a chdir underneath where the file is, so move up one level and try again
       parent = "#{dir}/..".gsub(/^(\.\/)*/, '')
       if File.expand_path(dir) == File.expand_path(parent)

--- a/lib/wrong/eventually.rb
+++ b/lib/wrong/eventually.rb
@@ -7,7 +7,6 @@ module Wrong
       timeout = options[:timeout] || 5
       delay = options[:delay] || 0.25
       last_error = nil
-      success = nil
       begin_time = Time.now      
       while (Time.now - begin_time) < timeout
         begin

--- a/lib/wrong/failure_message.rb
+++ b/lib/wrong/failure_message.rb
@@ -76,7 +76,6 @@ module Wrong
     def details
       @details ||= begin
         require "wrong/rainbow" if Wrong.config[:color]
-        s = ""
         parts = chunk.parts
 
         parts.shift while parts.first == "()" # the parser adds this sometimes

--- a/lib/wrong/message/string_comparison.rb
+++ b/lib/wrong/message/string_comparison.rb
@@ -52,7 +52,7 @@ module Wrong
     end
 
     def chunk(s)
-      prefix, middle, suffix = "...", "", "..."
+      prefix, suffix = "...", "..."
 
       start = different_at - @@prelude
       if start < 0

--- a/lib/wrong/terminal.rb
+++ b/lib/wrong/terminal.rb
@@ -35,7 +35,7 @@ module Wrong
 
     # Determines if a shell command exists by searching for it in ENV['PATH'].
     def self.command_exists?(command)
-      ENV['PATH'].split(File::PATH_SEPARATOR).any? { |d| File.exists? File.join(d, command) }
+      ENV['PATH'].split(File::PATH_SEPARATOR).any? { |d| File.exist? File.join(d, command) }
     end
 
 


### PR DESCRIPTION
Cleaned up some Ruby warnings that shows up when running under Ruby 2.1.2
