### PR TITLE
Add short-circuit return in Wrong::FailureMessage::wrap_and_indent, t…

### DIFF
--- a/lib/wrong/failure_message.rb
+++ b/lib/wrong/failure_message.rb
@@ -188,7 +188,9 @@ module Wrong
         while line.length > width
           s << line[0...width]
           s << newline(indent_wrapped_lines)
+          old_length = line.length
           line = line[width..-1]
+          return indented unless line.length < old_length
           if first_line
             width += starting_col - indent_wrapped_lines
             first_line = false


### PR DESCRIPTION
Add short-circuit return in Wrong::FailureMessage::wrap_and_indent, to prevent infinite loop in environments where the width of Wrong::Terminal.size is incorrectly set to 0 (or <=6).

The infinite loop can be reproduced with:

```
#!/usr/bin/env ruby
require 'wrong/assert'
include Wrong::Assert
ENV['COLUMNS'] = '6'
f = "aaaaa"
assert { f.nil? }
```

Yes, most terminal widths shouldn't be set to 0, but in my case a combination of iterm + emacs caused it to be so.
